### PR TITLE
chore: stop wrapping in git issues and prs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = true
 max_line_length = 0
 trim_trailing_whitespace = false
 
-[COMMIT_EDITMSG,GHI_ISSUE]
+[*_EDITMSG]
 max_line_length = 0


### PR DESCRIPTION
Update `.editorconfig` so that auto-wrapping is prevented in git issues and
pull-requests. This allows messages to be wrapped by container in Github rather
than forced to wrap at 80 chars. Also remove entry for `ghi` edit buffers because I am no longer using `ghi`.